### PR TITLE
Minor task fixes

### DIFF
--- a/tasks/certify_nodes.yml
+++ b/tasks/certify_nodes.yml
@@ -19,9 +19,19 @@
   args:
     chdir: "{{ ca_certs_dir }}"
   with_inventory_hostnames: all:!localhost
-
-- name: "Generate the CA trusted certificate"
+  
+- name: "Generate the CA trusted certificate (Debian)"
   shell: 'sudo openssl x509 -req -days 1825 -in "{{ item }}".csr -CA ca.pem -CAkey ca-priv-key.pem -CAcreateserial -out "{{ item }}"-cert.pem -extensions v3_req -extfile /usr/lib/ssl/openssl.cnf'
   args:
     chdir: "{{ ca_certs_dir }}"
   with_inventory_hostnames: all:!localhost
+  when: ansible_os_family == "Debian"
+  
+- name: "Generate the CA trusted certificate (RedHat)"
+  shell: 'sudo openssl x509 -req -days 1825 -in "{{ item }}".csr -CA ca.pem -CAkey ca-priv-key.pem -CAcreateserial -out "{{ item }}"-cert.pem -extensions v3_req -extfile /etc/pki/tls/openssl.cnf'
+  args:
+    chdir: "{{ ca_certs_dir }}"
+  with_inventory_hostnames: all:!localhost
+  when: ansible_os_family == "RedHat"
+
+

--- a/tasks/fetch_keys.yml
+++ b/tasks/fetch_keys.yml
@@ -12,5 +12,9 @@
   with_items:
   - "{{ ca_cert }}"
   - "{{ ca_key }}"
+- name: "copy wildcard ca.pem ca-priv-key.pem"
+  fetch: src="{{ ca_certs_dir }}/{{ item }}" dest="{{ ca_distribution_certs_dir }}/{{ item }}" flat=yes
+  with_items:
   - wildcard-cert.pem
   - wildcard-priv-key.pem
+  when: ca_wildcard is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
 - debug: var=ca_subject
 
 - include: ca-validations.yml
-  when: (ca_force_create is undefined) and (inventory_hostsname == hostvars[groups['infra-instances'][0]]['inventory_hostname'])
+  when: (ca_force_create is undefined) and (inventory_hostname == hostvars[groups['infra-instances'][0]]['inventory_hostname'])
 
 - include: ca-conf.yml
   when: ca_init is defined and ca_force_create == true # defaults to false ...


### PR DESCRIPTION
This change when applied fixes the following:
* Default openssl.cnf path for RHEL-based systems
* A typo in `inventory_hostname`
* using the wildcard flag to determine if there's a wildcard cert file before attempting to fetch it